### PR TITLE
Fixed a typo that caused an undefined reference error

### DIFF
--- a/src/VoiceMod.js
+++ b/src/VoiceMod.js
@@ -54,7 +54,7 @@ class VoiceMod{
           this.rotaryVoiceExpires = Date.now() + rotVoiceTime.remainingTime * 1000;
 
         this.internal.on('voiceLoadedEvent', ( voice ) => {
-          this.currentVoice = this.voices.find(x => x.id === voice.voiceID);
+          this.currentVoice = this.voices.find(x => x.id === voice.voiceId);
           this.currentVoice.parameters = voice.parameters;
         });
 


### PR DESCRIPTION
The API docs seem to be incorrect with the casing of ID as the docs do say it's `voiceID` but the actual application send `voiceId`.

This crash happens when you are connected to the application and open the VM client window and change the selected voice in the application.

Also would you be able to publish the latest to your npm package? 

Thanks