### PR TITLE
Event listener changes

### DIFF
--- a/src/internal.js
+++ b/src/internal.js
@@ -79,9 +79,9 @@ class VoiceModInternal extends events.EventEmitter {
     if(this.cb[data.id]){
       this.cb[data.id](data.payload);
       this.cb[data.id] = null;
-    }  
-    
-    if(VM_EVENTS.includes(data.action))
+    }
+
+    if(this.listenerCount(data.action))
       this.emit(data.action, data.payload);
   }
   onError(){


### PR DESCRIPTION
I made a change to allow anyone who uses the internal variable to just do an `.on("<event name>")` Sadly voicemod doesn't actually emit the events that they say they do. 

For example they send `voiceChangerEnabledEvent` and `voiceChangerDisabledEvent` for when you toggle the voice changer. They do the same for each toggle where they only send a Enabled/Disabled event.

I could have added each one to the VM_EVENTS array but I felt it would be easier to just check to see if the listener is enabled.

Let me know if I should have done something else for this.

Also don't forget to update npm 😜 